### PR TITLE
Making switches trigger targets

### DIFF
--- a/src/heronarts/p3lx/ui/component/UISwitch.java
+++ b/src/heronarts/p3lx/ui/component/UISwitch.java
@@ -30,11 +30,12 @@ import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.p3lx.ui.UI;
 import heronarts.p3lx.ui.UIFocus;
+import heronarts.p3lx.ui.UITriggerTarget;
 import processing.core.PGraphics;
 import processing.event.KeyEvent;
 import processing.event.MouseEvent;
 
-public class UISwitch extends UIParameterControl implements UIFocus {
+public class UISwitch extends UIParameterControl implements UIFocus, UITriggerTarget {
 
   public final static int SWITCH_MARGIN = 6;
   public final static int SWITCH_SIZE = 28;
@@ -63,6 +64,11 @@ public class UISwitch extends UIParameterControl implements UIFocus {
 
   private BooleanParameter getBooleanParameter() {
     return (BooleanParameter) this.parameter;
+  }
+
+  @Override
+  public BooleanParameter getTriggerTarget() {
+    return getBooleanParameter();
   }
 
   @Override


### PR DESCRIPTION
There's no way for patterns to accept trigger modulation by default.

This PR makes a UISwitch expose it's underlying BooleanParameter as a trigger target.  Thus, all a pattern needs to do is `addParameter(someBooleanParam)`, that will show up a UISwitch, and this PR makes the UISwitch trigger-able.