### PR TITLE
Adding ability to add user-custom UI components, specifically modulators

### DIFF
--- a/src/heronarts/p3lx/ui/mappings/AbstractUIFactoryRequestWithLX.java
+++ b/src/heronarts/p3lx/ui/mappings/AbstractUIFactoryRequestWithLX.java
@@ -1,0 +1,25 @@
+package heronarts.p3lx.ui.mappings;
+
+import heronarts.lx.LX;
+import heronarts.p3lx.ui.UI;
+
+
+public abstract class AbstractUIFactoryRequestWithLX implements UIFactoryRequestWithLX {
+  private final LX lx;
+  private final UI ui;
+
+  public AbstractUIFactoryRequestWithLX(LX lx, UI ui) {
+    this.lx = lx;
+    this.ui = ui;
+  }
+
+  @Override
+  public LX getLX() {
+    return lx;
+  }
+
+  @Override
+  public UI getUI() {
+    return ui;
+  }
+}

--- a/src/heronarts/p3lx/ui/mappings/ComponentToUIRegistry.java
+++ b/src/heronarts/p3lx/ui/mappings/ComponentToUIRegistry.java
@@ -1,0 +1,45 @@
+package heronarts.p3lx.ui.mappings;
+
+import heronarts.p3lx.ui.UI2dComponent;
+
+import java.util.LinkedList;
+
+/**
+ * Provides a mechanism to register UI factories that map some underlying component types to UI's.
+ *
+ * UI's are P3LX classes.  Underlying component types are LX classes.  A user might want to implement their own
+ * components and/or UI's.
+ *
+ * This registry allows one to separate UI from core logic while making everything user-extensible by just registering
+ * an appropriate factory.  eg, in P3LXStudio, we might have for the modulators pane:
+ *   - {@link heronarts.lx.audio.BandGate} --> {@link heronarts.p3lx.ui.studio.modulation.UIBandGate}
+ *   - {@link heronarts.lx.modulator.VariableLFO} --> {@link heronarts.p3lx.ui.studio.modulation.UIVariableLFO}
+ *   - some user modulator --> some custom UI
+ *
+ * @param <T> Type of input components this registry is limited to mapping to (eg {@link heronarts.lx.modulator.LXModulator})
+ * @param <R> Type of {@link UIFactoryRequest} that provides context-specific params for factories
+ * @param <O> Output UI component type, if more specific than {@link UI2dComponent}
+ */
+public class ComponentToUIRegistry <T, R extends UIFactoryRequest, O extends UI2dComponent> {
+  private LinkedList<UIFactory<T, R, O>> uiFactories = new LinkedList<>();
+  private final R commonRequest;
+
+  public ComponentToUIRegistry(R commonRequest) {
+    this.commonRequest = commonRequest;
+  }
+
+  public ComponentToUIRegistry<T, R, O> registerFactory(UIFactory<T, R, O> factory) {
+    uiFactories.addFirst(factory);
+    return this;
+  }
+
+  public O getComponent(T forObject) {
+    for (UIFactory<T, R, O> factory : uiFactories) {
+      if (factory.canBuildUIFor(forObject)) {
+        return factory.buildUI(commonRequest, forObject);
+      }
+    }
+
+    throw new RuntimeException("No UI registered for object type: " + forObject.getClass().getName());
+  }
+}

--- a/src/heronarts/p3lx/ui/mappings/UIFactory.java
+++ b/src/heronarts/p3lx/ui/mappings/UIFactory.java
@@ -1,0 +1,25 @@
+package heronarts.p3lx.ui.mappings;
+
+import heronarts.p3lx.ui.UI2dComponent;
+
+/**
+ * Implementations will define how to create a new UI for an object given a particular UI registry's request type
+ *
+ * @param <T> Type of input components this registry is limited to mapping to (eg {@link heronarts.lx.modulator.LXModulator})
+ * @param <R> Type of {@link UIFactoryRequest} that provides context-specific params for factories
+ * @param <O> Output UI component type, if more specific than {@link UI2dComponent}
+ */
+public interface UIFactory <T, R extends UIFactoryRequest, O extends UI2dComponent> {
+
+  /**
+   * Reports whether this factory supports creating a UI for a given object
+   *
+   * Usually this is an instanceof check, ie <pre>return forObject instanceof ThingBuildingUIFor;</pre>
+   *
+   * @param forObject The object building a UI for
+   * @return True if this factory can build a UI for this object
+   */
+  boolean canBuildUIFor(T forObject);
+
+  O buildUI(R request, T forObject);
+}

--- a/src/heronarts/p3lx/ui/mappings/UIFactoryRequest.java
+++ b/src/heronarts/p3lx/ui/mappings/UIFactoryRequest.java
@@ -1,0 +1,16 @@
+package heronarts.p3lx.ui.mappings;
+
+/**
+ * Param container to a {@link UIFactory} that supplies the common context-specific parameters needed to construct a new
+ * {@link heronarts.p3lx.ui.UI2dComponent} in the context of the registry's usage.
+ *
+ * At minimum, a request should specify the parameters needed by the UI2dComponent constructor:
+ * {@link heronarts.p3lx.ui.UI2dComponent#UI2dComponent(float, float, float, float)}
+ */
+public interface UIFactoryRequest {
+  float getX();
+
+  float getY();
+
+  float getWidth();
+}

--- a/src/heronarts/p3lx/ui/mappings/UIFactoryRequestWithLX.java
+++ b/src/heronarts/p3lx/ui/mappings/UIFactoryRequestWithLX.java
@@ -1,0 +1,13 @@
+package heronarts.p3lx.ui.mappings;
+
+import heronarts.lx.LX;
+import heronarts.p3lx.ui.UI;
+
+/**
+ * A {@link UIFactoryRequest} that provides .lx and .ui params
+ */
+public interface UIFactoryRequestWithLX extends UIFactoryRequest {
+  LX getLX();
+
+  UI getUI();
+}

--- a/src/heronarts/p3lx/ui/studio/UIRightPane.java
+++ b/src/heronarts/p3lx/ui/studio/UIRightPane.java
@@ -61,6 +61,15 @@ import heronarts.p3lx.ui.studio.modulation.UIVariableLFO;
 import heronarts.p3lx.ui.studio.osc.UIOscManager;
 import processing.core.PGraphics;
 
+/**
+ * Right pane UI in LX Studio.
+ *
+ * Has two tabs: global modulators and OSC/MIDI mappings.
+ *
+ * The modulators tabs draws UIs for all global modulators added to the global {@link LXModulationEngine}
+ * at lx.engine.modulation.  If you add a custom modulator, register a UI for it
+ * using {@link #registerModulatorUI(UIFactory)}.
+ */
 public class UIRightPane extends UIPane {
 
   private final LX lx;

--- a/src/heronarts/p3lx/ui/studio/UIRightPane.java
+++ b/src/heronarts/p3lx/ui/studio/UIRightPane.java
@@ -35,15 +35,20 @@ import heronarts.lx.modulator.LXModulator;
 import heronarts.lx.modulator.MacroKnobs;
 import heronarts.lx.modulator.MultiStageEnvelope;
 import heronarts.lx.modulator.VariableLFO;
+import heronarts.lx.parameter.LXCompoundModulation;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
 import heronarts.lx.parameter.LXTriggerModulation;
-import heronarts.lx.parameter.LXCompoundModulation;
 import heronarts.p3lx.ui.UI;
+import heronarts.p3lx.ui.UI2dComponent;
 import heronarts.p3lx.ui.UI2dContainer;
 import heronarts.p3lx.ui.UI2dScrollContext;
 import heronarts.p3lx.ui.UIObject;
 import heronarts.p3lx.ui.component.UIButton;
+import heronarts.p3lx.ui.mappings.AbstractUIFactoryRequestWithLX;
+import heronarts.p3lx.ui.mappings.ComponentToUIRegistry;
+import heronarts.p3lx.ui.mappings.UIFactory;
+import heronarts.p3lx.ui.mappings.UIFactoryRequestWithLX;
 import heronarts.p3lx.ui.studio.midi.UIMidiInputs;
 import heronarts.p3lx.ui.studio.midi.UIMidiMappings;
 import heronarts.p3lx.ui.studio.midi.UIMidiSurfaces;
@@ -72,6 +77,8 @@ public class UIRightPane extends UIPane {
   private int envCount = 1;
   private int beatCount = 1;
   private int macroCount = 1;
+
+  private ComponentToUIRegistry<LXModulator, UIFactoryRequestWithLX, UI2dComponent> modulatorUIRegistry;
 
   public UIRightPane(UI ui, final LX lx) {
     super(ui, lx, new String[] { "MODULATION", "OSC + MIDI" }, ui.getWidth() - WIDTH, WIDTH);
@@ -197,6 +204,90 @@ public class UIRightPane extends UIPane {
       }
     });
 
+
+    // Build modulator UI registry with default component --> UI mappings
+    final UI2dScrollContext modulationContext = this.modulation;
+    UIFactoryRequestWithLX commonRequest = new AbstractUIFactoryRequestWithLX(lx, ui) {
+      @Override
+      public float getX() {
+        return 0; // modulator UI2dComponents always have x=0
+      }
+
+      @Override
+      public float getY() {
+        return 0; // modulator UI2dComponents always have y=0
+      }
+
+      @Override
+      public float getWidth() {
+        return modulationContext.getContentWidth();
+      }
+    };
+
+    modulatorUIRegistry = new ComponentToUIRegistry<>(commonRequest);
+
+    modulatorUIRegistry
+        // VariableLFO --> UIVariableLFO
+        .registerFactory(new UIFactory<LXModulator, UIFactoryRequestWithLX, UI2dComponent>() {
+          @Override
+          public boolean canBuildUIFor(LXModulator forObject) {
+            return forObject instanceof VariableLFO;
+          }
+
+          @Override
+          public UI2dComponent buildUI(UIFactoryRequestWithLX req, LXModulator forObject) {
+            return new UIVariableLFO(req.getUI(), req.getLX(), (VariableLFO) forObject,
+                req.getX(), req.getY(), req.getWidth()
+            );
+          }
+        })
+
+        // MultiStageEnvelope --> UIMultiStageEnvelope
+        .registerFactory(new UIFactory<LXModulator, UIFactoryRequestWithLX, UI2dComponent>() {
+          @Override
+          public boolean canBuildUIFor(LXModulator forObject) {
+            return forObject instanceof MultiStageEnvelope;
+          }
+
+          @Override
+          public UI2dComponent buildUI(UIFactoryRequestWithLX req, LXModulator forObject) {
+            return new UIMultiStageEnvelope(req.getUI(), req.getLX(), (MultiStageEnvelope) forObject,
+                req.getX(), req.getY(), req.getWidth()
+            );
+          }
+        })
+
+        // BandGate --> UIBandGate
+        .registerFactory(new UIFactory<LXModulator, UIFactoryRequestWithLX, UI2dComponent>() {
+          @Override
+          public boolean canBuildUIFor(LXModulator forObject) {
+            return forObject instanceof BandGate;
+          }
+
+          @Override
+          public UI2dComponent buildUI(UIFactoryRequestWithLX req, LXModulator forObject) {
+            return new UIBandGate(req.getUI(), req.getLX(), (BandGate) forObject,
+                req.getX(), req.getY(), req.getWidth()
+            );
+          }
+        })
+
+        // MacroKnobs --> UIMacroKnobs
+        .registerFactory(new UIFactory<LXModulator, UIFactoryRequestWithLX, UI2dComponent>() {
+          @Override
+          public boolean canBuildUIFor(LXModulator forObject) {
+            return forObject instanceof MacroKnobs;
+          }
+
+          @Override
+          public UI2dComponent buildUI(UIFactoryRequestWithLX req, LXModulator forObject) {
+            return new UIMacroKnobs(req.getUI(), req.getLX(), (MacroKnobs) forObject,
+                req.getX(), req.getY(), req.getWidth()
+            );
+          }
+        });
+
+
     for (LXModulator modulator : lx.engine.modulation.getModulators()) {
       addModulator(modulator);
     }
@@ -226,6 +317,22 @@ public class UIRightPane extends UIPane {
     });
   }
 
+  /**
+   * Adds a mapping to build a custom modulator UI.
+   *
+   * If you add custom modulators to the lx.engine.modulation {@link LXModulationEngine}, you need to define a UI
+   * mapping for them using this method.
+   *
+   * @param modulatorUIFactory Factory that can create your modulation
+   * @return this pane, for chaining
+   */
+  public UIRightPane registerModulatorUI(
+      UIFactory<LXModulator, UIFactoryRequestWithLX, UI2dComponent> modulatorUIFactory
+  ) {
+    this.modulatorUIRegistry.registerFactory(modulatorUIFactory);
+    return this;
+  }
+
   private UIModulator findModulator(LXParameter parameter) {
     for (UIObject child : this.modulation) {
       if (child instanceof UIModulator) {
@@ -239,17 +346,8 @@ public class UIRightPane extends UIPane {
   }
 
   private void addModulator(LXModulator modulator) {
-    if (modulator instanceof VariableLFO) {
-      new UIVariableLFO(this.ui, this.lx, (VariableLFO) modulator, 0, 0, this.modulation.getContentWidth()).addToContainer(this.modulation, 1);
-    } else if (modulator instanceof MultiStageEnvelope) {
-      new UIMultiStageEnvelope(this.ui, this.lx, (MultiStageEnvelope) modulator, 0, 0, this.modulation.getContentWidth()).addToContainer(this.modulation, 1);
-    } else if (modulator instanceof BandGate) {
-      new UIBandGate(this.ui, this.lx, (BandGate) modulator, 0, 0, this.modulation.getContentWidth()).addToContainer(this.modulation, 1);
-    } else if (modulator instanceof MacroKnobs) {
-      new UIMacroKnobs(this.ui, this.lx, (MacroKnobs) modulator, 0, 0, this.modulation.getContentWidth()).addToContainer(this.modulation, 1);
-    } else {
-      System.err.println("No UI available for modulator type: " + modulator.getClass().getName());
-    }
+    modulatorUIRegistry.getComponent(modulator)
+        .addToContainer(this.modulation, 1);
   }
 
   private void removeModulator(LXModulator modulator) {

--- a/src/heronarts/p3lx/ui/studio/UIRightPane.java
+++ b/src/heronarts/p3lx/ui/studio/UIRightPane.java
@@ -68,7 +68,7 @@ import processing.core.PGraphics;
  *
  * The modulators tabs draws UIs for all global modulators added to the global {@link LXModulationEngine}
  * at lx.engine.modulation.  If you add a custom modulator, register a UI for it
- * using {@link #registerModulatorUI(UIFactory)}.
+ * using {@link #registerModulatorUI(UIFactory)} in your {@link heronarts.p3lx.LXStudio#onUIReady} implementation.
  */
 public class UIRightPane extends UIPane {
 


### PR DESCRIPTION
Studio comes with a few pre-built UI's for built-in `LXModulator`'s, but this is all hardcoded: https://github.com/heronarts/P3LX/blob/f61a62d65ed3f449fc39275064b9a26a8e72ec89/src/heronarts/p3lx/ui/studio/UIRightPane.java#L241

This PR adds the ability to define custom UI's for custom modulators.  For example:

```java
lxStudio = new LXStudio(...) {
  @Override
  public void onUIReady(LXStudio lx, LXStudio.UI ui) {
    ui.rightPane.registerModulatorUI(new UIFactory<LXModulator, UIFactoryRequestWithLX, UI2dComponent>() {
      @Override
      public boolean canBuildUIFor(LXModulator forObject) {
        return forObject instanceof MyCustomModulator;
      }

      @Override
      public UI2dComponent buildUI(UIFactoryRequestWithLX req, LXModulator forObject) {
        return new MyCustomModulatorUI(req.getUI(), req.getLX(), forObject,
            req.getX(), req.getY(), req.getWidth()
        );
      }
    });
    lx.engine.modulation.addModulator(myCustomModulator);
  }
}
```

This PR introduces three new classes: `ComponentToUIRegistry`, `UIFactory`, and `UIFactoryRequest`.

The basic idea is that a `ComponentToUIRegistry` is a context-specific list of `UIFactory`'s.  Studio's `UIRightPane` is one example of a UI registry context: the right pane needs a list of factories that know how to create some `UI2dComponent` given an `LXModulator`. 

`ComponentToUIRegistry`'s are context-specific -- eg a right-pane modulator UI factory is different than a device-modulator UI factory, even though they may operate on the same underlying modulator classes (they produce different UI's).  Because they're context-specific, there needs to be a mechanism to pass context-specific parameters to the factory.  That's the purpose of the third class, `UIFactoryRequest`.  Using generics, a `ComponentToUIRegistry` declaration defines what type of `UIFactoryRequest`'s its `UIFactory`'s should expect.

This PR implements this UI registry just for studio's RightPane (that was my immediate need).  But basically it can be injected into any place there's a hardcoded mapping of components to P3LX UI's (eg https://github.com/heronarts/P3LX/blob/c086b7b9ea44f61ff7cae07c317cdd8f4d2ef65e/src/heronarts/p3lx/ui/studio/device/UIDeviceModulators.java#L171)