### PR TITLE
Adding generics declaration to UIModulator.Factory to avoid unnecessary cast

### DIFF
--- a/src/heronarts/p3lx/ui/studio/UIRightPane.java
+++ b/src/heronarts/p3lx/ui/studio/UIRightPane.java
@@ -40,10 +40,10 @@ import heronarts.lx.modulator.LXModulator;
 import heronarts.lx.modulator.MacroKnobs;
 import heronarts.lx.modulator.MultiStageEnvelope;
 import heronarts.lx.modulator.VariableLFO;
+import heronarts.lx.parameter.LXCompoundModulation;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
 import heronarts.lx.parameter.LXTriggerModulation;
-import heronarts.lx.parameter.LXCompoundModulation;
 import heronarts.p3lx.ui.UI;
 import heronarts.p3lx.ui.UI2dContainer;
 import heronarts.p3lx.ui.UI2dScrollContext;
@@ -99,11 +99,11 @@ public class UIRightPane extends UIPane {
     buildModulationUI();
   }
 
-  public void registerModulatorUI(Class<? extends LXModulator> modulatorClass, Class<? extends UIModulator> uiClass) {
-    registerModulatorUI(modulatorClass, new UIModulator.DefaultFactory(modulatorClass, uiClass));
+  public <T extends LXModulator> void registerModulatorUI(Class<T> modulatorClass, Class<? extends UIModulator> uiClass) {
+    registerModulatorUI(modulatorClass, new UIModulator.DefaultFactory<>(modulatorClass, uiClass));
   }
 
-  public void registerModulatorUI(Class<? extends LXModulator> modulatorClass, UIModulator.Factory uiFactory) {
+  public <T extends LXModulator> void registerModulatorUI(Class<T> modulatorClass, UIModulator.Factory<T> uiFactory) {
     if (!this.modulatorUIRegistry.containsKey(modulatorClass)) {
       this.modulatorClasses.addFirst(modulatorClass);
     }

--- a/src/heronarts/p3lx/ui/studio/modulation/UIModulator.java
+++ b/src/heronarts/p3lx/ui/studio/modulation/UIModulator.java
@@ -62,21 +62,21 @@ import processing.event.MouseEvent;
 
 public abstract class UIModulator extends UI2dContainer implements UIMouseFocus, UIKeyFocus, UITriggerTarget {
 
-  public interface Factory {
-    public UIModulator buildUI(UI ui, LX lx, LXModulator modulator, float x, float y, float width);
+  public interface Factory<T extends LXModulator> {
+    UIModulator buildUI(UI ui, LX lx, T modulator, float x, float y, float width);
   }
 
-  public static class DefaultFactory implements Factory {
+  public static class DefaultFactory<T extends LXModulator> implements Factory<T> {
 
-    private final Class<? extends LXModulator> modulatorClass;
+    private final Class<T> modulatorClass;
     private final Class<? extends UIModulator> uiClass;
 
-    public DefaultFactory(Class<? extends LXModulator> modulatorClass, Class<? extends UIModulator> uiClass) {
+    public DefaultFactory(Class<T> modulatorClass, Class<? extends UIModulator> uiClass) {
       this.modulatorClass = modulatorClass;
       this.uiClass = uiClass;
     }
 
-    public UIModulator buildUI(UI ui, LX lx, LXModulator modulator, float x, float y, float width) {
+    public UIModulator buildUI(UI ui, LX lx, T modulator, float x, float y, float width) {
       try {
         return
           this.uiClass


### PR DESCRIPTION
Quick tweak to the UIModulator.Factory stuff.  Changes

```java
public interface Factory {
  public UIModulator buildUI(UI ui, LX lx, LXModulator modulator, float x, float y, float width);
}
```

by declaring LXModulator's type as a generic to avoid a cast against `modulator` in your `buildUI()` impl when your custom UI takes a specific LXModulator class:

```java
public interface Factory<T extends LXModulator> {
  UIModulator buildUI(UI ui, LX lx, T modulator, float x, float y, float width);
}
```

