### PR TITLE
Tweaking ordering of LXStudio.UI lifecycle hooks to make UI factories easier to use

### DIFF
--- a/src/heronarts/p3lx/LXStudio.java
+++ b/src/heronarts/p3lx/LXStudio.java
@@ -90,7 +90,6 @@ public class LXStudio extends P3LX {
 
     UI(final LXStudio lx) {
       super(lx);
-      initialize(lx, this);
       setBackgroundColor(this.theme.getDarkBackgroundColor());
 
       this.preview = new PreviewWindow(this, lx, UILeftPane.WIDTH, 0, this.applet.width - UILeftPane.WIDTH - UIRightPane.WIDTH, this.applet.height - UIBottomTray.HEIGHT - UIContextualHelpBar.VISIBLE_HEIGHT);
@@ -98,6 +97,9 @@ public class LXStudio extends P3LX {
       this.rightPane = new UIRightPane(this, lx);
       this.bottomTray = new UIBottomTray(this, lx);
       this.helpBar = new UIContextualHelpBar(this);
+
+      initialize(lx, this); // let user configure all elements, eg UIRightPane#registerModulatorUI
+      this.rightPane.buildUI();
 
       addLayer(this.preview);
       addLayer(this.leftPane);

--- a/src/heronarts/p3lx/LXStudio.java
+++ b/src/heronarts/p3lx/LXStudio.java
@@ -92,14 +92,17 @@ public class LXStudio extends P3LX {
       super(lx);
       setBackgroundColor(this.theme.getDarkBackgroundColor());
 
+      // Construct instances that might need initialization
+      this.rightPane = new UIRightPane(this, lx);
+
+      // let user configure all elements, eg UIRightPane#registerModulatorUI
+      initialize(lx, this);
+
       this.preview = new PreviewWindow(this, lx, UILeftPane.WIDTH, 0, this.applet.width - UILeftPane.WIDTH - UIRightPane.WIDTH, this.applet.height - UIBottomTray.HEIGHT - UIContextualHelpBar.VISIBLE_HEIGHT);
       this.leftPane = new UILeftPane(this, lx);
-      this.rightPane = new UIRightPane(this, lx);
+      this.rightPane.buildUI();
       this.bottomTray = new UIBottomTray(this, lx);
       this.helpBar = new UIContextualHelpBar(this);
-
-      initialize(lx, this); // let user configure all elements, eg UIRightPane#registerModulatorUI
-      this.rightPane.buildUI();
 
       addLayer(this.preview);
       addLayer(this.leftPane);

--- a/src/heronarts/p3lx/ui/studio/UIRightPane.java
+++ b/src/heronarts/p3lx/ui/studio/UIRightPane.java
@@ -94,9 +94,6 @@ public class UIRightPane extends UIPane {
     registerModulatorUI(MultiStageEnvelope.class, UIMultiStageEnvelope.class);
     registerModulatorUI(BandGate.class, UIBandGate.class);
     registerModulatorUI(MacroKnobs.class, UIMacroKnobs.class);
-
-    buildMidiUI();
-    buildModulationUI();
   }
 
   public void registerModulatorUI(Class<? extends LXModulator> modulatorClass, Class<? extends UIModulator> uiClass) {
@@ -108,6 +105,12 @@ public class UIRightPane extends UIPane {
       this.modulatorClasses.addFirst(modulatorClass);
     }
     this.modulatorUIRegistry.put(modulatorClass, uiFactory);
+  }
+
+  /** {@link heronarts.p3lx.LXStudio.UI} lifecycle hook that creates all the UI elements */
+  public void buildUI() {
+    buildMidiUI();
+    buildModulationUI();
   }
 
   private void buildMidiUI() {


### PR DESCRIPTION
Found another issue while using the UI factory stuff. This one needs a bit of context... lemme describe the problem and you can see if you like the proposed solution.

Making a new LXStudio instance is like this:

```java
new LXStudio(this, myModel, false) {

      @Override
      public void initialize(LXStudio lx, LXStudio.UI ui) {
        // create all components, etc.
      }

      @Override
      public void onUIReady(LXStudio lx, LXStudio.UI ui) {
        // add any UI stuff
      }
}
```

To create our custom modulator UI's, two calls need to be made:
- First, add the modulator to the engine: `lx.engine.modulation.addModulator(customModulator);`
- Then, tell P3LX how to build it: eg `ui.rightPane.registerModulatorUI(CustomModulator.class, UICustomModulator::new)`

It seems like the right place to do both of these should be in the initialize() function.  At the very least, since modulators are independent of any GUI, the right place to add modulators to the engine is in the initialize() function. ie setting up your LX instance should be independent of any P3LX UI (we actually have it rigged that the same init code is run in a headless build (LX only, no-P3LX) as the gui build (P3LX)).  It seems reasonable then that you would also tell the UI *how* to build everything during initialization, not waiting until the ui is ready.

And here lies the problem: the `initialize()` hook is called before `ui.rightPane` is constructed, so `ui.rightPane.registerModulatorUI()` throws a NPE.

Furthermore, UIRightPane tries to build all of it's modulators in it's constructor, so if you've already added a modulator to the engine, there's no time to call `registerModulatorUI` to teach it how to build it.

This PR does two things:
1. Move the initialize() hook until after ui.rightPane is constructed so there's no NPE during initialization
2. Defer building the UI's until after the initialize() hook is called so that the user can call `registerModulatorUI` and teach it how to build its UI's

Right now, you can do the modulator factory stuff if you call both `registerModulatorUI() and addModulator()` in `onUIReady()` instead of `initialize()`, but this feels like the wrong place and requires different code paths if you're building a headless build vs. a gui build (even though adding modulators should be independent of a GUI, you would have to `addModulator()` in one place on a non-GUI build and in a different place on a GUI build).  Seems like the lifecycle order should support doing all this in `initialize()`.