### PR TITLE
Making full labels appear in context bar to get full text when cut off

### DIFF
--- a/src/heronarts/p3lx/ui/component/UILabel.java
+++ b/src/heronarts/p3lx/ui/component/UILabel.java
@@ -145,4 +145,9 @@ public class UILabel extends UI2dComponent {
     }
     return this;
   }
+
+  @Override
+  public String getDescription() {
+    return this.label;
+  }
 }


### PR DESCRIPTION
Another quick one...

labels can get cut off, especially with modulations that have long text, ie "Channel Name | Pattern Name | Parameter Name".  

This does it so all labels' full text appears in the context bar when mousing over them so you can see what the full parameter is when it gets cut off.

(Applies to any UILabel, not just modulation names, but I think that's desirable... it's not only modulations that get cut off.)