### PR TITLE
Add UI component for BoundedFunctionalParameter

### DIFF
--- a/src/heronarts/p3lx/ui/component/UICompoundParameterControl.java
+++ b/src/heronarts/p3lx/ui/component/UICompoundParameterControl.java
@@ -27,8 +27,8 @@ package heronarts.p3lx.ui.component;
 import java.util.ArrayList;
 import java.util.List;
 
-import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.parameter.LXListenableParameter;
+import heronarts.lx.parameter.LXNormalizedParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
 import heronarts.lx.parameter.LXCompoundModulation;
@@ -65,7 +65,7 @@ public class UICompoundParameterControl extends UIParameterControl {
   }
 
   @Override
-  public UIParameterControl setParameter(LXListenableNormalizedParameter parameter) {
+  public UIParameterControl setParameter(LXNormalizedParameter parameter) {
     for (LXListenableParameter p : this.modulationParameters) {
       p.removeListener(this.redrawListener);
     }

--- a/src/heronarts/p3lx/ui/component/UIFunctionalKnob.java
+++ b/src/heronarts/p3lx/ui/component/UIFunctionalKnob.java
@@ -1,0 +1,93 @@
+package heronarts.p3lx.ui.component;
+
+import heronarts.lx.parameter.LXNormalizedParameter;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.p3lx.ui.UI;
+import heronarts.p3lx.ui.UIFocus;
+import heronarts.p3lx.ui.UITimerTask;
+import processing.core.PConstants;
+import processing.core.PGraphics;
+
+public class UIFunctionalKnob extends UIParameterControl implements UIFocus {
+
+  private double lastParameterValue = 0;
+
+  private final UITimerTask checkRedrawTask = new UITimerTask(30, UITimerTask.Mode.FPS) {
+    @Override
+    public void run() {
+      double parameterValue = getNormalized();
+      if (parameterValue != lastParameterValue) {
+        redraw();
+      }
+      lastParameterValue = parameterValue;
+    }
+  };
+
+  public UIFunctionalKnob(LXNormalizedParameter parameter) {
+    this();
+    setParameter(parameter);
+  }
+
+  public UIFunctionalKnob() {
+    this(0, 0);
+  }
+
+  public UIFunctionalKnob(float x, float y) {
+    this(x, y, UIKnob.WIDTH, UIKnob.KNOB_SIZE);
+  }
+
+  public UIFunctionalKnob(float x, float y, float w, float h) {
+    super(x, y, w, h);
+    this.keyEditable = true;
+    enableImmediateEdit(true);
+    addLoopTask(checkRedrawTask);
+  }
+
+  @Override
+  protected void onDraw(UI ui, PGraphics pg) {
+    // value refers to the current, function-derived value of the control's parameter.
+    float value = (float) getNormalized();
+    float valueEnd = UIKnob.ARC_START + value * UIKnob.ARC_RANGE;
+    float valueStart;
+    switch (this.polarity) {
+    case BIPOLAR: valueStart = UIKnob.ARC_START + UIKnob.ARC_RANGE/2; break;
+    default: case UNIPOLAR: valueStart = UIKnob.ARC_START; break;
+    }
+
+    float arcSize = UIKnob.KNOB_SIZE;
+    pg.noStroke();
+    pg.ellipseMode(PConstants.CENTER);
+
+    // Outer fill
+    pg.noStroke();
+    pg.fill(ui.theme.getControlBackgroundColor());
+    pg.arc(UIKnob.ARC_CENTER_X, UIKnob.ARC_CENTER_Y, arcSize, arcSize, UIKnob.ARC_START, UIKnob.ARC_END);
+
+    // Compute color for value fill
+    int valueColor;
+    if (isEnabled()) {
+      valueColor = getModulatedValueColor(ui.theme.getPrimaryColor());
+    } else {
+      int disabled = ui.theme.getControlDisabledColor();
+      valueColor = disabled;
+    }
+
+    // Value indication
+    pg.fill(valueColor);
+    pg.arc(UIKnob.ARC_CENTER_X, UIKnob.ARC_CENTER_Y, arcSize, arcSize, Math.min(valueStart, valueEnd), Math.max(valueStart, valueEnd));
+
+    // Center tick mark for bipolar knobs
+    if (this.polarity == LXParameter.Polarity.BIPOLAR) {
+      pg.stroke(0xff333333);
+      pg.line(UIKnob.ARC_CENTER_X, UIKnob.ARC_CENTER_Y, UIKnob.ARC_CENTER_X, UIKnob.ARC_CENTER_Y - arcSize/2);
+    }
+
+    // Center dot
+    pg.noStroke();
+    pg.fill(0xff333333);
+    pg.ellipse(UIKnob.ARC_CENTER_X, UIKnob.ARC_CENTER_Y, 8, 8);
+
+    super.onDraw(ui,  pg);
+  }
+
+}

--- a/src/heronarts/p3lx/ui/component/UIKnob.java
+++ b/src/heronarts/p3lx/ui/component/UIKnob.java
@@ -45,11 +45,11 @@ public class UIKnob extends UICompoundParameterControl implements UIFocus {
   public final static int HEIGHT = KNOB_SIZE + LABEL_MARGIN + LABEL_HEIGHT;
 
   private final static float KNOB_INDENT = .4f;
-  private final static int ARC_CENTER_X = WIDTH / 2;
-  private final static int ARC_CENTER_Y = KNOB_SIZE / 2;
-  private final static float ARC_START = PConstants.HALF_PI + KNOB_INDENT;
-  private final static float ARC_RANGE = PConstants.TWO_PI - 2 * KNOB_INDENT;
-  private final static float ARC_END = ARC_START + ARC_RANGE;
+  final static int ARC_CENTER_X = WIDTH / 2;
+  final static int ARC_CENTER_Y = KNOB_SIZE / 2;
+  final static float ARC_START = PConstants.HALF_PI + KNOB_INDENT;
+  final static float ARC_RANGE = PConstants.TWO_PI - 2 * KNOB_INDENT;
+  final static float ARC_END = ARC_START + ARC_RANGE;
 
   public UIKnob(LXListenableNormalizedParameter parameter) {
     this();

--- a/src/heronarts/p3lx/ui/component/UIParameterControl.java
+++ b/src/heronarts/p3lx/ui/component/UIParameterControl.java
@@ -32,6 +32,7 @@ import processing.event.MouseEvent;
 
 import heronarts.lx.osc.LXOscEngine;
 import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.BoundedFunctionalParameter;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
 import heronarts.lx.parameter.LXListenableNormalizedParameter;
@@ -54,7 +55,7 @@ public abstract class UIParameterControl extends UIInputBox implements UIControl
 
   private boolean showValue = false;
 
-  protected LXListenableNormalizedParameter parameter = null;
+  protected LXNormalizedParameter parameter = null;
 
   protected LXParameter.Polarity polarity = LXParameter.Polarity.UNIPOLAR;
 
@@ -156,7 +157,7 @@ public abstract class UIParameterControl extends UIInputBox implements UIControl
     return this;
   }
 
-  public LXListenableNormalizedParameter getParameter() {
+  public LXNormalizedParameter getParameter() {
     return this.parameter;
   }
 
@@ -168,14 +169,18 @@ public abstract class UIParameterControl extends UIInputBox implements UIControl
     return this;
   }
 
-  public UIParameterControl setParameter(LXListenableNormalizedParameter parameter) {
+  public UIParameterControl setParameter(LXNormalizedParameter parameter) {
     if (this.parameter != null) {
-      this.parameter.removeListener(this);
+      if (parameter instanceof LXListenableNormalizedParameter) {
+        ((LXListenableNormalizedParameter)this.parameter).removeListener(this);
+      }
     }
     this.parameter = parameter;
     if (this.parameter != null) {
       this.polarity = this.parameter.getPolarity();
-      this.parameter.addListener(this);
+      if (parameter instanceof LXListenableNormalizedParameter) {
+        ((LXListenableNormalizedParameter)this.parameter).addListener(this);
+      }
     }
     redraw();
     return this;
@@ -197,6 +202,8 @@ public abstract class UIParameterControl extends UIInputBox implements UIControl
         return ((BooleanParameter) this.parameter).isOn() ? "ON" : "OFF";
       } else if (this.parameter instanceof CompoundParameter) {
         return this.parameter.getFormatter().format(((CompoundParameter) this.parameter).getBaseValue());
+      } else if (this.parameter instanceof BoundedFunctionalParameter) {
+        return this.parameter.getFormatter().format(((BoundedFunctionalParameter) this.parameter).getValue());
       } else {
         return this.parameter.getFormatter().format(this.parameter.getValue());
       }
@@ -380,7 +387,7 @@ public abstract class UIParameterControl extends UIInputBox implements UIControl
     return null;
   }
 
-  private LXListenableNormalizedParameter getMappableParameter() {
+  private LXNormalizedParameter getMappableParameter() {
     if (this.parameter != null && this.parameter.getComponent() != null) {
       return this.parameter;
     }

--- a/src/heronarts/p3lx/ui/component/UISwitch.java
+++ b/src/heronarts/p3lx/ui/component/UISwitch.java
@@ -25,7 +25,7 @@
 package heronarts.p3lx.ui.component;
 
 import heronarts.lx.parameter.BooleanParameter;
-import heronarts.lx.parameter.LXListenableNormalizedParameter;
+import heronarts.lx.parameter.LXNormalizedParameter;
 import heronarts.p3lx.ui.UI;
 import heronarts.p3lx.ui.UIFocus;
 import heronarts.p3lx.ui.UITriggerSource;
@@ -52,7 +52,7 @@ public class UISwitch extends UIParameterControl implements UIFocus, UITriggerTa
   }
 
   @Override
-  public UIParameterControl setParameter(LXListenableNormalizedParameter parameter) {
+  public UIParameterControl setParameter(LXNormalizedParameter parameter) {
     if (!(parameter instanceof BooleanParameter)) {
       throw new IllegalArgumentException("UISwitch may only take BooleanParameter");
     }


### PR DESCRIPTION
Added UIFunctionalKnob as a default UI object for BoundedFunctionalParameter.

I elected to change the type of property UIParameterControl.parameter from LXListenableNormalizedParameter to LXNormalizedParameter to allow UIParameterControl to remain a base class of all three default parameter UI objects.  At first I expected this to cause a mess but the damage appears to be minimal.